### PR TITLE
fix: Namespace incorrect formatting fix.

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -1672,7 +1672,11 @@ func elementToBytes(el *etree.Element) ([]byte, error) {
 	doc := etree.NewDocument()
 	doc.SetRoot(el.Copy())
 	for space, uri := range namespaces {
-		doc.Root().CreateAttr("xmlns:"+space, uri)
+		if space == "" {
+			doc.Root().CreateAttr("xmlns", uri)
+		} else {
+			doc.Root().CreateAttr("xmlns:"+space, uri)
+		}
 	}
 
 	return doc.WriteToBytes()


### PR DESCRIPTION
When the `elementToBytes` function is called it incorrectly applies namespaces to elements by assuming all namespaces will have a prefix. If a namespace is the _default_ namespace, it would be applied with the following syntax: 

`<xmlns:='URI' />` which is invalid XML. 

When parsing Assertions that do not have an explicit namespace, the incorrect syntax would cause an error, as the Assertion is expected to have the proper namespace. 

