### PR TITLE
Team orgs patch: Fix empty namespace issue and correct lib internal paths to avoid types mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/crewjam/saml/samlsp"
+	"github.com/clerk/saml/samlsp"
 )
 
 func hello(w http.ResponseWriter, r *http.Request) {
@@ -154,4 +154,4 @@ The SAML specification is a collection of PDFs (sadly):
 
 ## Security Issues
 
-Please do not report security issues in the issue tracker. Rather, please contact me directly at ross@kndr.org ([PGP Key `78B6038B3B9DFB88`](https://keybase.io/crewjam)). If your issue is *not* a security issue, please use the issue tracker so other contributors can help.
+Please do not report security issues in the issue tracker. Rather, please contact me directly at ross@kndr.org ([PGP Key `78B6038B3B9DFB88`](https://keybase.io/crewjam)). If your issue is _not_ a security issue, please use the issue tracker so other contributors can help.

--- a/example/idp/idp.go
+++ b/example/idp/idp.go
@@ -11,8 +11,8 @@ import (
 	"github.com/zenazn/goji"
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/crewjam/saml/logger"
-	"github.com/crewjam/saml/samlidp"
+	"github.com/clerk/saml/logger"
+	"github.com/clerk/saml/samlidp"
 )
 
 var key = func() crypto.PrivateKey {

--- a/example/service.go
+++ b/example/service.go
@@ -19,7 +19,7 @@ import (
 	"github.com/zenazn/goji"
 	"github.com/zenazn/goji/web"
 
-	"github.com/crewjam/saml/samlsp"
+	"github.com/clerk/saml/samlsp"
 )
 
 var links = map[string]Link{}

--- a/example/trivial/trivial.go
+++ b/example/trivial/trivial.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/crewjam/saml/samlsp"
+	"github.com/clerk/saml/samlsp"
 )
 
 var samlMiddleware *samlsp.Middleware

--- a/identity_provider.go
+++ b/identity_provider.go
@@ -21,8 +21,8 @@ import (
 	xrv "github.com/mattermost/xml-roundtrip-validator"
 	dsig "github.com/russellhaering/goxmldsig"
 
-	"github.com/crewjam/saml/logger"
-	"github.com/crewjam/saml/xmlenc"
+	"github.com/clerk/saml/logger"
+	"github.com/clerk/saml/xmlenc"
 )
 
 // Session represents a user session. It is returned by the

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -28,9 +28,9 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	dsig "github.com/russellhaering/goxmldsig"
 
-	"github.com/crewjam/saml/logger"
-	"github.com/crewjam/saml/testsaml"
-	"github.com/crewjam/saml/xmlenc"
+	"github.com/clerk/saml/logger"
+	"github.com/clerk/saml/testsaml"
+	"github.com/clerk/saml/xmlenc"
 )
 
 type IdentityProviderTest struct {

--- a/saml.go
+++ b/saml.go
@@ -76,7 +76,7 @@
 //	"net/http"
 //	"net/url"
 //
-//	"github.com/crewjam/saml/samlsp"
+//	"github.com/clerk/saml/samlsp"
 //
 // )
 //

--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/zenazn/goji/web"
 
-	"github.com/crewjam/saml"
-	"github.com/crewjam/saml/logger"
+	"github.com/clerk/saml"
+	"github.com/clerk/saml/logger"
 )
 
 // Options represent the parameters to New() for creating a new IDP server

--- a/samlidp/samlidp_test.go
+++ b/samlidp/samlidp_test.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 
-	"github.com/crewjam/saml"
-	"github.com/crewjam/saml/logger"
+	"github.com/clerk/saml"
+	"github.com/clerk/saml/logger"
 )
 
 type testRandomReader struct {

--- a/samlidp/service.go
+++ b/samlidp/service.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/zenazn/goji/web"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 // Service represents a configured SP for whom this IDP provides authentication services.

--- a/samlidp/session.go
+++ b/samlidp/session.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/zenazn/goji/web"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 var sessionMaxAge = time.Hour

--- a/samlidp/util.go
+++ b/samlidp/util.go
@@ -8,7 +8,7 @@ import (
 
 	xrv "github.com/mattermost/xml-roundtrip-validator"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 func randomBytes(n int) []byte {

--- a/samlsp/error.go
+++ b/samlsp/error.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 // ErrorFunction is a callback that is invoked to return an error to the

--- a/samlsp/fetch_metadata.go
+++ b/samlsp/fetch_metadata.go
@@ -12,9 +12,9 @@ import (
 	"github.com/crewjam/httperr"
 	xrv "github.com/mattermost/xml-roundtrip-validator"
 
-	"github.com/crewjam/saml/logger"
+	"github.com/clerk/saml/logger"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 // ParseMetadata parses arbitrary SAML IDP metadata.

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"net/http"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 // Middleware implements middleware than allows a web application

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -23,8 +23,8 @@ import (
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/golden"
 
-	"github.com/crewjam/saml"
-	"github.com/crewjam/saml/testsaml"
+	"github.com/clerk/saml"
+	"github.com/clerk/saml/testsaml"
 )
 
 type MiddlewareTest struct {

--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -9,7 +9,7 @@ import (
 
 	dsig "github.com/russellhaering/goxmldsig"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 // Options represents the parameters for creating a new middleware

--- a/samlsp/request_tracker_cookie.go
+++ b/samlsp/request_tracker_cookie.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 var _ RequestTracker = CookieRequestTracker{}

--- a/samlsp/request_tracker_jwt.go
+++ b/samlsp/request_tracker_jwt.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 var defaultJWTSigningMethod = jwt.SigningMethodRS256

--- a/samlsp/session.go
+++ b/samlsp/session.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 // Session is an interface implemented to contain a session.

--- a/samlsp/session_cookie.go
+++ b/samlsp/session_cookie.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 const defaultSessionCookieName = "token"

--- a/samlsp/session_cookie_test.go
+++ b/samlsp/session_cookie_test.go
@@ -8,7 +8,7 @@ import (
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 func TestCookieSameSite(t *testing.T) {

--- a/samlsp/session_jwt.go
+++ b/samlsp/session_jwt.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 const (

--- a/samlsp/util.go
+++ b/samlsp/util.go
@@ -3,7 +3,7 @@ package samlsp
 import (
 	"io"
 
-	"github.com/crewjam/saml"
+	"github.com/clerk/saml"
 )
 
 func randomBytes(n int) []byte {

--- a/service_provider.go
+++ b/service_provider.go
@@ -23,8 +23,8 @@ import (
 	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/russellhaering/goxmldsig/etreeutils"
 
-	"github.com/crewjam/saml/logger"
-	"github.com/crewjam/saml/xmlenc"
+	"github.com/clerk/saml/logger"
+	"github.com/clerk/saml/xmlenc"
 )
 
 // NameIDFormat is the format of the id

--- a/service_provider.go
+++ b/service_provider.go
@@ -1672,7 +1672,11 @@ func elementToBytes(el *etree.Element) ([]byte, error) {
 	doc := etree.NewDocument()
 	doc.SetRoot(el.Copy())
 	for space, uri := range namespaces {
-		doc.Root().CreateAttr("xmlns:"+space, uri)
+		if space == "" {
+			doc.Root().CreateAttr("xmlns", uri)
+		} else {
+			doc.Root().CreateAttr("xmlns:"+space, uri)
+		}
 	}
 
 	return doc.WriteToBytes()

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/beevik/etree"
 	dsig "github.com/russellhaering/goxmldsig"
 
-	"github.com/crewjam/saml/testsaml"
+	"github.com/clerk/saml/testsaml"
 )
 
 type ServiceProviderTest struct {


### PR DESCRIPTION
This PR adds two commits.

- The first commit updates all the paths referenced on the lib to point to `github.com/clerk/saml` instead of `github.com/crewjam/saml`. This was causing an issue, because the internal struct fields were referencing crewjam's repo, but all the values were coming from clerk's repo.
Example:
![CleanShot 2024-11-28 at 13 17 12](https://github.com/user-attachments/assets/504b528a-4a02-4d72-b1c8-688cb8f5b664)
So the `saml` package was being resolved differently by the lib and by the application. The lib pointing to `*(github.com/crewjam/saml).AssertionMaker` and the app to `*(github.com/clerk/saml).AssertionMaker`

- The second commit is from @jeremy-clerk, to fix an issue with empty namespaces. This was happening for one of our customers and this is the reason why we're introducing the fork. https://github.com/clerk/saml/pull/2