### PR TITLE
Fix: Fixed issue where default namespace was overwritten

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -1672,13 +1672,14 @@ func elementToBytes(el *etree.Element) ([]byte, error) {
 	doc := etree.NewDocument()
 	doc.SetRoot(el.Copy())
 	for space, uri := range namespaces {
-		if space == "" {
+		if space == "" && len(doc.Root().SelectAttr("xmlns").Value) == 0 {
 			doc.Root().CreateAttr("xmlns", uri)
 		} else {
 			doc.Root().CreateAttr("xmlns:"+space, uri)
 		}
 	}
-
+	xmlstr, _ := doc.WriteToString()
+	fmt.Printf("%s", xmlstr)
 	return doc.WriteToBytes()
 }
 

--- a/service_provider.go
+++ b/service_provider.go
@@ -1678,8 +1678,6 @@ func elementToBytes(el *etree.Element) ([]byte, error) {
 			doc.Root().CreateAttr("xmlns:"+space, uri)
 		}
 	}
-	xmlstr, _ := doc.WriteToString()
-	fmt.Printf("%s", xmlstr)
 	return doc.WriteToBytes()
 }
 


### PR DESCRIPTION
Fixes a bug caused by a previous PR that caused the default namespace to be overwritten. This caused saml requests to fail. 

Checks if the default namespace exists on the element before applying the attribute. 