### PR TITLE
fix(HandleIDPInitiated): Remove recursive rlock

### DIFF
--- a/samlidp/shortcut.go
+++ b/samlidp/shortcut.go
@@ -110,7 +110,5 @@ func (s *Server) HandleIDPInitiated(c web.C, w http.ResponseWriter, r *http.Requ
 		relayState = c.URLParams["*"]
 	}
 
-	s.idpConfigMu.RLock()
-	defer s.idpConfigMu.RUnlock()
 	s.IDP.ServeIDPInitiated(w, r, shortcut.ServiceProviderID, relayState)
 }


### PR DESCRIPTION
There is a recursive RLock in the path `HandleIDPInitiated` -> `ServeIDPInitiated` -> `GetServiceProvider`. This can lead to deadlocks under concurrent requests. The outer RLock is unnecessary, because `GetServiceProvider` is the only call to access the protected `serviceProviders` map, and it already guards acces with RLock.

For further context from a similar issue, see:
https://github.com/clerk/saml/commit/91716e8856a3a1723129577d6dfb5352d06fc837